### PR TITLE
fix pagination with Zola 0.16.0

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -62,12 +62,12 @@
 	{% include "partials/disqus.html" %}
 
   <div class="pagination">
-  	{% if page.later -%}
-  		<a href="{{ page.later.permalink | safe }}" class="left arrow">&#8592;</a>
+  	{% if page.higher -%}
+  		<a href="{{ page.higher.permalink | safe }}" class="left arrow">&#8592;</a>
   	{%- endif %}
-		<a href="#" class="top">Top</a>
-		{% if page.earlier -%}
-			<a href="{{ page.earlier.permalink | safe }}" class="right arrow">&#8594;</a>
-		{%- endif %}
+	<a href="#" class="top">Top</a>
+	{% if page.lower -%}
+		<a href="{{ page.lower.permalink | safe }}" class="right arrow">&#8594;</a>
+	{%- endif %}
   </div>
 {% endblock content %}


### PR DESCRIPTION
Only lower/higher are now supported for a page's pagination. Noticed this as the pagination didn't appear anymore.

See Zola's changelog: 
https://github.com/getzola/zola/blob/53ce6db057101b8a24631ac4212ab4f9f3d145ae/CHANGELOG.md#breaking

> Unify all pages sorting variable names in templates to lower/higher in order to make it easy to re-use templates and it was becoming hard to come up with names to be honest

Also fixed a minor indentation issue.